### PR TITLE
Add detect_encoding() function and adapt docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,40 @@ Usage
 ```jlcon
 julia> using UnicodeExtras
 
-julia> b = encode("Ålborg", "iso-8859-1")
-6-element Array{Uint8,1}:
+julia> b = encode("Ålborg is eating apples", "iso-8859-1")
+23-element Array{Uint8,1}:
  0xc5
  0x6c
  0x62
  0x6f
  0x72
  0x67
+ 0x20
+ 0x69
+ 0x73
+ 0x20
+    ⋮
+ 0x69
+ 0x6e
+ 0x67
+ 0x20
+ 0x61
+ 0x70
+ 0x70
+ 0x6c
+ 0x65
+ 0x73
 
 julia> decode(b, "iso-8859-1")
-"Ålborg"
+"Ålborg is eating apples"
+
+julia> detect_encoding(b)
+5-element Array{ASCIIString,1}:
+ "ISO-8859-1"
+ "ISO-8859-2"
+ "Shift_JIS" 
+ "GB18030"   
+ "Big5"      
 ```
 
 ### Case handling

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ UnicodeExtras
 Installation
 ------------
 
-    julia> Pkg.clone("git://github.com/nolta/UnicodeExtras.git")
+    julia> Pkg.clone("git://github.com/nolta/UnicodeExtras.jl.git")
 
 Usage
 -----

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.2
 ICU 0.3
+Compat 0.7

--- a/src/UnicodeExtras.jl
+++ b/src/UnicodeExtras.jl
@@ -5,6 +5,7 @@ using ICU
 export
     UnicodeText,
     decode,
+    detect_encoding,
     encode,
     foldcase,
     set_locale, # from ICU
@@ -132,6 +133,15 @@ end
 
 function encode(s::ByteString, encoding::ASCIIString)
     transcode(s.data, "utf8", encoding)
+end
+
+function detect_encoding(b::Array{Uint8,1})
+   cs = ucsdet_open()
+   ucsdet_setText(cs, b)
+   a = ucsdet_detectAll(cs)
+   ret = ASCIIString[ucsdet_getName(x) for x in a]
+   ucsdet_close(cs)
+   ret
 end
 
 end # module


### PR DESCRIPTION
Depends on https://github.com/nolta/ICU.jl/pull/9.

I had to cheat a little in the examples because with only the first word encoding detection was really poor, which would have been quite ridiculous. OTOH it's pretty good with just a few more words, and the typical use case is more about large files.
